### PR TITLE
Heartbeat interval is now configureable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+.pio
+CMakeLists.txt
+CMakeListsPrivate.txt
+cmake-build-*/ 

--- a/src/ArduinoOcpp.cpp
+++ b/src/ArduinoOcpp.cpp
@@ -40,7 +40,6 @@ std::function<bool()> connectorEnergizedSampler = NULL;
 bool connectorEnergizedLastState = false;
 SmartChargingService *smartChargingService;
 ChargePointStatusService *chargePointStatusService;
-HeartbeatService *heartbeatService;
 OnLimitChange onLimitChange;
 OcppTime *ocppTime;
 
@@ -143,7 +142,7 @@ void OCPP_initialize(OcppSocket *ocppSocket, float V_eff, ArduinoOcpp::Filesyste
         Serial.print(F("[ArduinoOcpp] OCPP_initialize(ocppSocket): ocppSocket cannot be NULL!\n"));
         return;
     }
-    
+
     configuration_init(fsOpt); //call before each other library call
 
     ocppEngine_initialize(ocppSocket);
@@ -154,7 +153,6 @@ void OCPP_initialize(OcppSocket *ocppSocket, float V_eff, ArduinoOcpp::Filesyste
     smartChargingService = new SmartChargingService(11000.0f, V_eff, OCPP_NUMCONNECTORS, ocppTime, fsOpt); //default charging limit: 11kW
     chargePointStatusService = new ChargePointStatusService(OCPP_NUMCONNECTORS, ocppTime); //Constructor adds instance to ocppEngine in constructor
     meteringService = new MeteringService(OCPP_NUMCONNECTORS, ocppTime);
-    heartbeatService = new HeartbeatService();
 
     OCPP_initialized = true;
 }
@@ -186,8 +184,6 @@ void OCPP_loop() {
     if (powerSampler != NULL || energySampler != NULL) {
         meteringService->loop();        //optional
     }
-
-    heartbeatService->loop();
 
     bool evRequestsEnergyNewState = true;
     if (evRequestsEnergySampler != NULL) {

--- a/src/ArduinoOcpp/Core/OcppEngine.cpp
+++ b/src/ArduinoOcpp/Core/OcppEngine.cpp
@@ -11,11 +11,13 @@
 #include <ArduinoOcpp/Core/OcppError.h>
 
 #include <Variants.h>
+#include <ArduinoOcpp/Tasks/Heartbeat/HeartbeatService.h>
 
 namespace ArduinoOcpp {
 namespace OcppEngine {
 
 OcppSocket *ocppSocket;
+HeartbeatService *heartbeatService = NULL;
 SmartChargingService *ocppEngine_smartChargingService = NULL;
 ChargePointStatusService *ocppEngine_chargePointStatusService = NULL;
 MeteringService *ocppEngine_meteringService = NULL;
@@ -43,6 +45,10 @@ void ocppEngine_initialize(OcppSocket *ocppSocket){
   mConnection = new OcppConnection(ocppSock);
 }
 
+void ocppEngine_startHeartbeat(int interval){
+    heartbeatService = new HeartbeatService(interval);
+}
+
 void initiateOcppOperation(OcppOperation *o) {
   mConnection->initiateOcppOperation(o);
 }
@@ -50,6 +56,7 @@ void initiateOcppOperation(OcppOperation *o) {
 void ocppEngine_loop() {
   ocppSock->loop();
   mConnection->loop();
+  if (heartbeatService != nullptr) heartbeatService->loop();
 }
 
 #if 0

--- a/src/ArduinoOcpp/Core/OcppEngine.h
+++ b/src/ArduinoOcpp/Core/OcppEngine.h
@@ -38,6 +38,8 @@ void handleErrMessage(JsonDocument *json);
 
 void initiateOcppOperation(OcppOperation *o);
 
+void ocppEngine_startHeartbeat(int interval);
+
 void ocppEngine_loop();
 
 void setSmartChargingService(SmartChargingService *scs);

--- a/src/ArduinoOcpp/MessagesV16/BootNotification.cpp
+++ b/src/ArduinoOcpp/MessagesV16/BootNotification.cpp
@@ -83,8 +83,9 @@ void BootNotification::processConf(JsonObject payload){
     } else {
         Serial.print(F("[BootNotification] Error reading time string. Missing attribute currentTime of type string\n"));
     }
-    
-    //int interval = payload["interval"] | 86400; //not used in this implementation
+
+    int interval = payload["interval"] | 86400;
+    ocppEngine_startHeartbeat(interval);
 
     const char* status = payload["status"] | "Invalid";
 

--- a/src/ArduinoOcpp/MessagesV16/Heartbeat.cpp
+++ b/src/ArduinoOcpp/MessagesV16/Heartbeat.cpp
@@ -18,11 +18,8 @@ const char* Heartbeat::getOcppOperationType(){
 }
 
 DynamicJsonDocument* Heartbeat::createReq() {
-    DynamicJsonDocument *doc = new DynamicJsonDocument(0);
-    //JsonObject payload = doc->to<JsonObject>();
-    /*
-    * Empty payload
-    */
+    DynamicJsonDocument *doc = new DynamicJsonDocument(JSON_OBJECT_SIZE(0));
+    JsonObject payload = doc->to<JsonObject>();
     return doc;
 }
 

--- a/src/ArduinoOcpp/Tasks/Heartbeat/HeartbeatService.cpp
+++ b/src/ArduinoOcpp/Tasks/Heartbeat/HeartbeatService.cpp
@@ -9,8 +9,9 @@
 
 using namespace ArduinoOcpp;
 
-HeartbeatService::HeartbeatService() {
-    heartbeatInterval = declareConfiguration("HeartbeatInterval", 86400);
+HeartbeatService::HeartbeatService(int interval) {
+    heartbeatInterval = declareConfiguration("HeartbeatInterval", interval);
+    *heartbeatInterval = interval;
     lastHeartbeat = millis();
 }
 

--- a/src/ArduinoOcpp/Tasks/Heartbeat/HeartbeatService.h
+++ b/src/ArduinoOcpp/Tasks/Heartbeat/HeartbeatService.h
@@ -9,19 +9,15 @@
 #include <ArduinoOcpp/Core/Configuration.h>
 
 namespace ArduinoOcpp {
+    class HeartbeatService {
+    private:
+        ulong lastHeartbeat;
+        std::shared_ptr<ArduinoOcpp::Configuration<int>> heartbeatInterval;
+    public:
+        HeartbeatService(int interval);
 
-class HeartbeatService {
-private:
-
-    ulong lastHeartbeat;
-    std::shared_ptr<ArduinoOcpp::Configuration<int>> heartbeatInterval;
-
-public:
-    HeartbeatService();
-
-    void loop();
-};
-
+        void loop();
+    };
 }
 
 #endif


### PR DESCRIPTION
Hi,

Despite it not being a requirement of OCPP 1.6J there are still some server implementations that rely on Heartbeat messages in order to keep track of a charge points online status, so I've added the ability for the Heartbeat service to change based on the boot notification

Let me know what you think

Regards,
Brian