### PR TITLE
AddMeterValueInput accepts float values

### DIFF
--- a/src/ArduinoOcpp.cpp
+++ b/src/ArduinoOcpp.cpp
@@ -412,7 +412,7 @@ void addErrorCodeInput(std::function<const char *()> errorCodeInput, unsigned in
     connector->addConnectorErrorCodeSampler(errorCodeInput);
 }
 
-void addMeterValueInput(std::function<int32_t ()> valueInput, const char *measurand, const char *unit, const char *location, const char *phase, unsigned int connectorId) {
+void addMeterValueInput(std::function<float ()> valueInput, const char *measurand, const char *unit, const char *location, const char *phase, unsigned int connectorId) {
     if (!ocppEngine) {
         AO_DBG_ERR("OCPP uninitialized"); //please call OCPP_initialize before
         return;
@@ -438,10 +438,10 @@ void addMeterValueInput(std::function<int32_t ()> valueInput, const char *measur
     if (phase)
         properties.setPhase(phase);
 
-    auto valueSampler = std::unique_ptr<ArduinoOcpp::SampledValueSamplerConcrete<int32_t, ArduinoOcpp::SampledValueDeSerializer<int32_t>>>(
-                                    new ArduinoOcpp::SampledValueSamplerConcrete<int32_t, ArduinoOcpp::SampledValueDeSerializer<int32_t>>(
+    auto valueSampler = std::unique_ptr<ArduinoOcpp::SampledValueSamplerConcrete<float, ArduinoOcpp::SampledValueDeSerializer<float>>>(
+                                    new ArduinoOcpp::SampledValueSamplerConcrete<float, ArduinoOcpp::SampledValueDeSerializer<float>>(
                 properties,
-                [valueInput] (ArduinoOcpp::ReadingContext) -> int32_t {return valueInput();}));
+                [valueInput] (ArduinoOcpp::ReadingContext) {return valueInput();}));
     addMeterValueInput(std::move(valueSampler), connectorId);
 }
 

--- a/src/ArduinoOcpp.cpp
+++ b/src/ArduinoOcpp.cpp
@@ -324,8 +324,8 @@ void setEnergyMeterInput(std::function<float()> energyInput, unsigned int connec
     SampledValueProperties meterProperties;
     meterProperties.setMeasurand("Energy.Active.Import.Register");
     meterProperties.setUnit("Wh");
-    auto mvs = std::unique_ptr<SampledValueSamplerConcrete<int32_t, SampledValueDeSerializer<int32_t>>>(
-                           new SampledValueSamplerConcrete<int32_t, SampledValueDeSerializer<int32_t>>(
+    auto mvs = std::unique_ptr<SampledValueSamplerConcrete<float, SampledValueDeSerializer<float>>>(
+                           new SampledValueSamplerConcrete<float, SampledValueDeSerializer<float>>(
             meterProperties,
             [energyInput] (ReadingContext) {return energyInput();}
     ));
@@ -347,8 +347,8 @@ void setPowerMeterInput(std::function<float()> powerInput, unsigned int connecto
     SampledValueProperties meterProperties;
     meterProperties.setMeasurand("Power.Active.Import");
     meterProperties.setUnit("W");
-    auto mvs = std::unique_ptr<SampledValueSamplerConcrete<int32_t, SampledValueDeSerializer<int32_t>>>(
-                           new SampledValueSamplerConcrete<int32_t, SampledValueDeSerializer<int32_t>>(
+    auto mvs = std::unique_ptr<SampledValueSamplerConcrete<float, SampledValueDeSerializer<float>>>(
+                           new SampledValueSamplerConcrete<float, SampledValueDeSerializer<float>>(
             meterProperties,
             [powerInput] (ReadingContext) {return powerInput();}
     ));

--- a/src/ArduinoOcpp.h
+++ b/src/ArduinoOcpp.h
@@ -206,7 +206,7 @@ void setEvseReadyInput(std::function<bool()> evseReadyInput, unsigned int connec
 
 void addErrorCodeInput(std::function<const char *()> errorCodeInput, unsigned int connectorId = 1); //Input for Error codes (please refer to OCPP 1.6, Edit2, p. 71 and 72 for valid error codes)
 
-void addMeterValueInput(std::function<int32_t ()> valueInput, const char *measurand = nullptr, const char *unit = nullptr, const char *location = nullptr, const char *phase = nullptr, unsigned int connectorId = 1); //integrate further metering Inputs
+void addMeterValueInput(std::function<float ()> valueInput, const char *measurand = nullptr, const char *unit = nullptr, const char *location = nullptr, const char *phase = nullptr, unsigned int connectorId = 1); //integrate further metering Inputs
 
 void addMeterValueInput(std::unique_ptr<ArduinoOcpp::SampledValueSampler> valueInput, unsigned int connectorId = 1); //integrate further metering Inputs (more extensive alternative)
 

--- a/src/ArduinoOcpp/Tasks/Metering/SampledValue.h
+++ b/src/ArduinoOcpp/Tasks/Metering/SampledValue.h
@@ -33,6 +33,19 @@ public:
     static int32_t toInteger(int32_t& val) {return val;}
 };
 
+template <>
+class SampledValueDeSerializer<float> { // Used in meterValues
+public:
+    static float deserialize(const char *str) {return atof(str);}
+    static bool ready(float& val) {return true;} //float is always valid
+    static std::string serialize(float& val) {
+        char str[20];
+        dtostrf(val,4,9,str);
+        return std::string(str);
+    }
+    static int32_t toInteger(float& val) {return (int32_t) val;}
+};
+
 class SampledValueProperties {
 private:
     std::string format;


### PR DESCRIPTION
Solves #112 , @matth-x  sorry about the delay
As mentioned in the issue, many Central Systems require precise measurements of MeterValues. In applications like this using float values is fundamental.