### PR TITLE
Fix ESP32 PWM configuration fault in SECC example

### DIFF
--- a/examples/SECC/README.md
+++ b/examples/SECC/README.md
@@ -6,17 +6,17 @@ With this sketch you can use an ESP8266/ESP32 as the central control unit of an 
 
 The communication controller can connect to an SAE&nbsp;J1772 driver using the GPIO pins of the ESP. Furthermore, it can show the online status and charge point availability status via status LEDs. Displays, RFID readers or energy meters are not supported, though for your project you can integrate further HW components of course.
 
-You can find the interface descriptions in `main.ino`. Please be aware that although this program modulates the maximum charge rate with PWM analogous to the SAE&nbsp;J1772 standard, the PWM signal does not reflect the EVSE state. The latter is encoded via the other GPIO pins.
+You can find the interface descriptions in `main.cpp`. Please be aware that although this program modulates the maximum charge rate with PWM analogous to the SAE&nbsp;J1772 standard, the PWM signal does not reflect the EVSE state. The latter is encoded via the other GPIO pins.
 
 ## Usage
 
 - Create an empty project in the PlatformIO IDE.
 - Copy the `platformio.ini` from this directory to your root directory. Alternatively, just add `https://github.com/tzapu/WiFiManager.git` to the lib_deps of your `platformio.ini`.
-- Copy the `main.ino` from this example folder into your source directory. Adapt the pinout settings if needed.
+- Copy the `main.cpp` from this example folder into your source directory. Adapt the pinout settings if needed.
 - Finished. You should be able to compile and upload the sketch onto your ESP.
 
 When booting, the ESP opens up the Wi-Fi configuration portal. Please connect your PC to the network with the SSID `EVSE-Config` within the first 30s of the boot routine of the ESP (the portal has a timeout). The passphrase is `evse1234`.
 
 ## Standalone mode
 
-If you just want to check out ArduinoOcpp you can run this sketch on an ESP without any peripherals. The pinout of the ESP8266-NodeMCU&nbsp;board is already fully configured in `main.ino` so that board is the most convenient to start testing.
+If you just want to check out ArduinoOcpp you can run this sketch on an ESP without any peripherals. The pinout of the ESP8266-NodeMCU&nbsp;board is already fully configured in `main.cpp` so that board is the most convenient to start testing.

--- a/examples/SECC/main.cpp
+++ b/examples/SECC/main.cpp
@@ -25,6 +25,9 @@
  * Interface to the SECC (Supply Equipment Communication Controller, e.g. the SAE J1772 module)
  */
 #define AMPERAGE_PIN 4 //modulated as PWM
+#if defined(ESP32)
+#define PWM_CHANNEL 0 //PWM channel (only for ESP32)
+#endif
 
 #define EV_PLUG_PIN 14 // Input pin | Read if an EV is connected to the EVSE
 #if defined(ESP32)
@@ -132,9 +135,9 @@ void setup() {
     pinMode(AMPERAGE_PIN, OUTPUT);
 #if defined(ESP32)
     pinMode(AMPERAGE_PIN, OUTPUT);
-    ledcSetup(0, 1000, 8); //channel=0, freq=1000Hz, range=(2^8)-1
-    ledcAttachPin(AMPERAGE_PIN, 0);
-    ledcWrite(AMPERAGE_PIN, 256); //256 is constant +3.3V DC
+    ledcSetup(PWM_CHANNEL, 1000, 8); //channel=PWM_CHANNEL, freq=1000Hz, range=(2^8)-1
+    ledcAttachPin(AMPERAGE_PIN, PWM_CHANNEL); //pin, channel
+    ledcWrite(PWM_CHANNEL, 256); //channel, duty cycle (256 is constant +3.3V DC)
 #elif defined(ESP8266)
     analogWriteRange(255); //range=(2^8)-1
     analogWriteFreq(1000); //freq=1000Hz
@@ -257,7 +260,7 @@ void setup() {
         }
 
 #if defined(ESP32)
-        ledcWrite(AMPERAGE_PIN, pwmVal);
+        ledcWrite(PWM_CHANNEL, pwmVal);
 #elif defined(ESP8266)
         analogWrite(AMPERAGE_PIN, pwmVal);
 #endif


### PR DESCRIPTION
ESP32 `ledcWrite` expects the pwm channel and dutycycle, see: [ledcWrite](https://github.com/espressif/arduino-esp32/blob/0d84018d969309addacbcc3e3782c1fadc95fbc8/cores/esp32/esp32-hal-ledc.c#L82).

At the moment this function is called with the GPIO pin number resulting in an infunctional pwm output.
The PR fixes this issue and adds an ESP32 specific parameter `PWM_CHANNEL`.