### PR TITLE
ConnectorMeterValuesRecorder: fix build on IDF 5.0+

### DIFF
--- a/src/ArduinoOcpp/Core/OcppTime.cpp
+++ b/src/ArduinoOcpp/Core/OcppTime.cpp
@@ -9,8 +9,8 @@
 
 namespace ArduinoOcpp {
 
-const OcppTimestamp MIN_TIME = OcppTimestamp(2010, 0, 0, 0, 0, 0);
-const OcppTimestamp MAX_TIME = OcppTimestamp(2037, 0, 0, 0, 0, 0);
+// const OcppTimestamp MIN_TIME = OcppTimestamp(2010, 0, 0, 0, 0, 0);
+// const OcppTimestamp MAX_TIME = OcppTimestamp(2037, 0, 0, 0, 0, 0);
 
 namespace Clocks {
 

--- a/src/ArduinoOcpp/Core/OcppTime.h
+++ b/src/ArduinoOcpp/Core/OcppTime.h
@@ -81,8 +81,10 @@ public:
     friend bool operator>=(const OcppTimestamp &lhs, const OcppTimestamp &rhs);
 };
 
-extern const OcppTimestamp MIN_TIME;
-extern const OcppTimestamp MAX_TIME;
+// extern const OcppTimestamp MIN_TIME;
+// extern const OcppTimestamp MAX_TIME;
+#define MIN_TIME OcppTimestamp(2010, 0, 0, 0, 0, 0)
+#define MAX_TIME OcppTimestamp(2037, 0, 0, 0, 0, 0)
 
 class OcppTime {
 private:

--- a/src/ArduinoOcpp/MessagesV16/GetCompositeSchedule.cpp
+++ b/src/ArduinoOcpp/MessagesV16/GetCompositeSchedule.cpp
@@ -78,7 +78,7 @@ std::unique_ptr<DynamicJsonDocument> GetCompositeSchedule::createConf(){
         char scheduleStart [JSONDATE_LENGTH + 1] {'\0'};
         auto startSchedule = (*compositeJson)["startSchedule"] | "";
         if (startSchedule[0] != '\0') {
-            strncpy(scheduleStart, startSchedule, JSONDATE_LENGTH + 1);
+            strncpy(scheduleStart, startSchedule, JSONDATE_LENGTH);
         } else {
             ocppModel->getOcppTime().getOcppTimestampNow().toJsonString(scheduleStart, JSONDATE_LENGTH + 1);
         }

--- a/src/ArduinoOcpp/MessagesV16/RemoteStartTransaction.cpp
+++ b/src/ArduinoOcpp/MessagesV16/RemoteStartTransaction.cpp
@@ -43,8 +43,11 @@ void RemoteStartTransaction::processReq(JsonObject payload) {
             errorCode = chargingProfile.containsKey("chargingProfileId") ? 
                         "PropertyConstraintViolation" : "FormationViolation";
         }
-        chargingProfileDoc = DynamicJsonDocument(chargingProfile.memoryUsage()); //copy TxProfile
-        chargingProfileDoc.set(chargingProfile);
+        if (chargingProfileDoc) {
+            delete(chargingProfileDoc);
+        }
+        chargingProfileDoc = new DynamicJsonDocument(chargingProfile.memoryUsage()); //copy TxProfile
+        chargingProfileDoc->set(chargingProfile);
     }
 }
 
@@ -106,11 +109,11 @@ std::unique_ptr<DynamicJsonDocument> RemoteStartTransaction::createConf(){
             connector->beginSession(idTag);
         }
 
-        if (!chargingProfileDoc.isNull()
+        if (chargingProfileDoc
                 && (ocppModel && ocppModel->getSmartChargingService())) {
             auto scService = ocppModel->getSmartChargingService();
 
-            JsonObject chargingProfile = chargingProfileDoc.as<JsonObject>();
+            JsonObject chargingProfile = chargingProfileDoc->as<JsonObject>();
             scService->setChargingProfile(chargingProfile);
             *sRmtProfileId = chargingProfile["chargingProfileId"].as<int>();
             AO_DBG_DEBUG("Charging Profile from RemoteStartTx set");

--- a/src/ArduinoOcpp/MessagesV16/RemoteStartTransaction.h
+++ b/src/ArduinoOcpp/MessagesV16/RemoteStartTransaction.h
@@ -15,7 +15,7 @@ class RemoteStartTransaction : public OcppMessage {
 private:
     int connectorId;
     char idTag [IDTAG_LEN_MAX + 1] = {'\0'};
-    DynamicJsonDocument chargingProfileDoc {0};
+    DynamicJsonDocument *chargingProfileDoc = NULL;
     
     const char *errorCode {nullptr};
 public:

--- a/src/ArduinoOcpp/Tasks/Metering/ConnectorMeterValuesRecorder.cpp
+++ b/src/ArduinoOcpp/Tasks/Metering/ConnectorMeterValuesRecorder.cpp
@@ -149,7 +149,7 @@ OcppMessage *ConnectorMeterValuesRecorder::loop() {
         if (dt <= 0 ||                              //normal case: interval elapsed
                 dt > *ClockAlignedDataInterval) {   //special case: clock has been adjusted or first run
 
-            AO_DBG_DEBUG("Clock aligned measurement %ds: %s", dt,
+            AO_DBG_DEBUG("Clock aligned measurement %" PRIu32 "s: %s", dt,
                 abs(dt) <= 60 ?
                 "in time (tolerance <= 60s)" : "off, e.g. because of first run. Ignore");
             if (abs(dt) <= 60) { //is measurement still "clock-aligned"?

--- a/src/ArduinoOcpp/Tasks/Metering/SampledValue.h
+++ b/src/ArduinoOcpp/Tasks/Metering/SampledValue.h
@@ -8,6 +8,7 @@
 #include <ArduinoJson.h>
 #include <memory>
 #include <functional>
+#include <inttypes.h>
 
 namespace ArduinoOcpp {
 
@@ -27,7 +28,7 @@ public:
     static bool ready(int32_t& val) {return true;} //int32_t is always valid
     static std::string serialize(int32_t& val) {
         char str [12] = {'\0'};
-        snprintf(str, 12, "%d", val);
+        snprintf(str, 12, "%" PRId32, val);
         return std::string(str);
     }
     static int32_t toInteger(int32_t& val) {return val;}
@@ -40,7 +41,8 @@ public:
     static bool ready(float& val) {return true;} //float is always valid
     static std::string serialize(float& val) {
         char str[20];
-        dtostrf(val,4,9,str);
+        snprintf(str, sizeof(str)-1, "%f", val);
+        // dtostrf(val,4,9,str);
         return std::string(str);
     }
     static int32_t toInteger(float& val) {return (int32_t) val;}

--- a/src/ArduinoOcpp_c.cpp
+++ b/src/ArduinoOcpp_c.cpp
@@ -187,10 +187,10 @@ void ao_authorize(const char *idTag, OnAuthorize onConfirmation, OnOcppAbort onA
 }
 
 void ao_beginTransaction(const char *idTag) {
-    ao_beginTransaction(idTag);
+    beginTransaction(idTag);
 }
 void ao_beginTransaction_m(unsigned int connectorId, const char *idTag) {
-    beginTransaction(idTag, 1);
+    beginTransaction(idTag, connectorId);
 }
 
 bool ao_endTransaction(const char *reason) {


### PR DESCRIPTION
Newer versions of esp-idf make printf formats a hard error. This
includes areas where integers are printed with "%d", since integers do
not necessarily have the ability to be formatted with "%d".

The workaround is to use PRId32 and PRIu32.

This fixes builds under ESP-IDF version 5.0+.