### PR TITLE
Decouple configurations from storage format

### DIFF
--- a/src/ArduinoOcpp/Core/Configuration.cpp
+++ b/src/ArduinoOcpp/Core/Configuration.cpp
@@ -17,31 +17,24 @@ std::shared_ptr<FilesystemAdapter> filesystem;
 template<class T>
 std::shared_ptr<Configuration<T>> createConfiguration(const char *key, T value) {
 
-    std::shared_ptr<Configuration<T>> configuration = std::make_shared<Configuration<T>>();
-        
-    if (!configuration->setKey(key)) {
-        AO_DBG_ERR("Cannot set key! Abort");
+    if (!key || !*key) {
+        AO_DBG_ERR("invalid args");
         return nullptr;
     }
 
-    *configuration = value;
+    std::shared_ptr<Configuration<T>> configuration = std::make_shared<Configuration<T>>(key, value);
 
     return configuration;
 }
 
 std::shared_ptr<Configuration<const char *>> createConfiguration(const char *key, const char *value) {
 
-    std::shared_ptr<Configuration<const char*>> configuration = std::make_shared<Configuration<const char*>>();
-        
-    if (!configuration->setKey(key)) {
-        AO_DBG_ERR("Cannot set key! Abort");
+    if (!key || !*key || !value) {
+        AO_DBG_ERR("invalid args");
         return nullptr;
     }
 
-    if (!configuration->setValue(value, strlen(value) + 1)) {
-        AO_DBG_ERR("Cannot set value! Abort");
-        return nullptr;
-    }
+    std::shared_ptr<Configuration<const char*>> configuration = std::make_shared<Configuration<const char*>>(key, value);
 
     return configuration;
 }

--- a/src/ArduinoOcpp/Core/ConfigurationContainer.cpp
+++ b/src/ArduinoOcpp/Core/ConfigurationContainer.cpp
@@ -8,11 +8,11 @@ namespace ArduinoOcpp {
 
 std::shared_ptr<AbstractConfiguration> ConfigurationContainer::getConfiguration(const char *key) {
     for (std::vector<std::shared_ptr<AbstractConfiguration>>::iterator configuration = configurations.begin(); configuration != configurations.end(); configuration++) {
-        if ((*configuration)->keyEquals(key)) {
+        if (!strcmp(key, (*configuration)->getKey())) {
             return *configuration;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 bool ConfigurationContainer::removeConfiguration(std::shared_ptr<AbstractConfiguration> configuration) {

--- a/src/ArduinoOcpp/Core/ConfigurationContainerFlash.cpp
+++ b/src/ArduinoOcpp/Core/ConfigurationContainerFlash.cpp
@@ -58,18 +58,27 @@ bool ConfigurationContainerFlash::load() {
     }
 
     for (JsonObject config : configurationsArray) {
+        const char *key = config["key"] | "";
+        if (!*key || !config.containsKey("value")) {
+            AO_DBG_ERR("corrupt config");
+            continue;
+        }
+
         const char *type = config["type"] | "Undefined";
 
         std::shared_ptr<AbstractConfiguration> configuration = nullptr;
 
-        if (!strcmp(type, SerializedType<int>::get())){
-            configuration = std::make_shared<Configuration<int>>(config);
-        } else if (!strcmp(type, SerializedType<float>::get())){
-            configuration = std::make_shared<Configuration<float>>(config);
-        } else if (!strcmp(type, SerializedType<bool>::get())){
-            configuration = std::make_shared<Configuration<bool>>(config);
-        } else if (!strcmp(type, SerializedType<const char *>::get())){
-            configuration = std::make_shared<Configuration<const char *>>(config);
+        if (!strcmp(type, SerializedType<int>::get()) && config["value"].is<int>()){
+            configuration = std::make_shared<Configuration<int>>(key, config["value"].as<int>());
+        } else if (!strcmp(type, SerializedType<float>::get()) && config["value"].is<float>()){
+            configuration = std::make_shared<Configuration<float>>(key, config["value"].as<float>());
+        } else if (!strcmp(type, SerializedType<bool>::get()) && config["value"].is<bool>()){
+            configuration = std::make_shared<Configuration<bool>>(key, config["value"].as<bool>());
+        } else if (!strcmp(type, SerializedType<const char *>::get()) && config["value"].is<const char*>()){
+            configuration = std::make_shared<Configuration<const char *>>(key, config["value"].as<const char*>());
+        } else {
+            AO_DBG_ERR("corrupt config");
+            continue;
         }
 
         if (configuration) {

--- a/src/ArduinoOcpp/Core/ConfigurationKeyValue.h
+++ b/src/ArduinoOcpp/Core/ConfigurationKeyValue.h
@@ -25,8 +25,7 @@ protected:
     uint16_t value_revision = 0; //number of memory-relevant changes of subclass-member "value" (deleting counts too). This will be important for the client to detect if there was a change
     bool initializedValue = false;
 
-    AbstractConfiguration();
-    AbstractConfiguration(JsonObject &storedKeyValuePair);
+    AbstractConfiguration(const char *key);
     size_t getStorageHeaderJsonCapacity();
     void storeStorageHeader(JsonObject &keyValuePair);
     size_t getOcppMsgHeaderJsonCapacity();
@@ -36,14 +35,12 @@ protected:
     bool permissionLocalClientCanWrite() {return localClientCanWrite;}
 public:
     virtual ~AbstractConfiguration();
-    bool setKey(const char *key);
-    void printKey();
+    const char *getKey();
 
     void requireRebootWhenChanged();
     bool requiresRebootWhenChanged();
 
     uint16_t getValueRevision();
-    bool keyEquals(const char *other);
 
     virtual std::unique_ptr<DynamicJsonDocument> toJsonStorageEntry() = 0;
     virtual std::unique_ptr<DynamicJsonDocument> toJsonOcppMsgEntry() = 0;
@@ -74,8 +71,7 @@ private:
     T value;
     size_t getValueJsonCapacity();
 public:
-    Configuration();
-    Configuration(JsonObject &storedKeyValuePair);
+    Configuration(const char *key, T value);
     const T &operator=(const T & newVal);
     operator T();
     bool isValid();
@@ -94,10 +90,8 @@ private:
 
     std::function<bool(const char*)> validator;
 public:
-    Configuration();
-    Configuration(JsonObject &storedKeyValuePair);
+    Configuration(const char *key, const char *value);
     ~Configuration();
-    bool setValue(const char *newVal, size_t buffsize);
     const char *operator=(const char *newVal);
     operator const char*();
     bool isValid();

--- a/src/ArduinoOcpp/Model/Authorization/AuthorizationService.cpp
+++ b/src/ArduinoOcpp/Model/Authorization/AuthorizationService.cpp
@@ -37,7 +37,7 @@ AuthorizationService::AuthorizationService(Context& context, std::shared_ptr<Fil
         if (!fProfilePlus.empty() && fProfilePlus.back() != ',')
             fProfilePlus += ",";
         fProfilePlus += fpId;
-        fProfile->setValue(fProfilePlus.c_str(), fProfilePlus.length() + 1);
+        *fProfile = fProfilePlus.c_str();
     }
 
     context.getOperationRegistry().registerOperation("GetLocalListVersion", [&context] () {

--- a/src/ArduinoOcpp/Model/ChargeControl/ChargeControlCommon.cpp
+++ b/src/ArduinoOcpp/Model/ChargeControl/ChargeControlCommon.cpp
@@ -41,14 +41,14 @@ ChargeControlCommon::ChargeControlCommon(Context& context, unsigned int numConn,
         if (!fProfilePlus.empty() && fProfilePlus.back() != ',')
             fProfilePlus += ",";
         fProfilePlus += fpIdCore;
-        fProfile->setValue(fProfilePlus.c_str(), fProfilePlus.length() + 1);
+        *fProfile = fProfilePlus.c_str();
     }
     if (!strstr(*fProfile, fpIdRTrigger)) {
         auto fProfilePlus = std::string(*fProfile);
         if (!fProfilePlus.empty() && fProfilePlus.back() != ',')
             fProfilePlus += ",";
         fProfilePlus += fpIdRTrigger;
-        fProfile->setValue(fProfilePlus.c_str(), fProfilePlus.length() + 1);
+        *fProfile = fProfilePlus.c_str();
     }
     
     /*

--- a/src/ArduinoOcpp/Model/Diagnostics/DiagnosticsService.cpp
+++ b/src/ArduinoOcpp/Model/Diagnostics/DiagnosticsService.cpp
@@ -23,7 +23,7 @@ DiagnosticsService::DiagnosticsService(Context& context) : context(context) {
         if (!fProfilePlus.empty() && fProfilePlus.back() != ',')
             fProfilePlus += ",";
         fProfilePlus += fpId;
-        fProfile->setValue(fProfilePlus.c_str(), fProfilePlus.length() + 1);
+        *fProfile = fProfilePlus.c_str();
     }
     
     context.getOperationRegistry().registerOperation("GetDiagnostics", [&context] () {

--- a/src/ArduinoOcpp/Model/FirmwareManagement/FirmwareService.cpp
+++ b/src/ArduinoOcpp/Model/FirmwareManagement/FirmwareService.cpp
@@ -33,7 +33,7 @@ FirmwareService::FirmwareService(Context& context) : context(context) {
         if (!fProfilePlus.empty() && fProfilePlus.back() != ',')
             fProfilePlus += ",";
         fProfilePlus += fpId;
-        fProfile->setValue(fProfilePlus.c_str(), fProfilePlus.length() + 1);
+        *fProfile = fProfilePlus.c_str();
     }
     
     context.getOperationRegistry().registerOperation("UpdateFirmware", [&context] () {
@@ -262,7 +262,7 @@ std::unique_ptr<Request> FirmwareService::getFirmwareStatusNotification() {
         size_t buildNoSize = previousBuildNumber->getBuffsize();
         if (strncmp(buildNumber.c_str(), *previousBuildNumber, buildNoSize)) {
             //new FW
-            previousBuildNumber->setValue(buildNumber.c_str(), buildNumber.length() + 1);
+            *previousBuildNumber = buildNumber.c_str();
             configuration_save();
 
             buildNumber.clear();

--- a/src/ArduinoOcpp/Model/Reservation/ReservationService.cpp
+++ b/src/ArduinoOcpp/Model/Reservation/ReservationService.cpp
@@ -32,7 +32,7 @@ ReservationService::ReservationService(Context& context, unsigned int numConnect
         if (!fProfilePlus.empty() && fProfilePlus.back() != ',')
             fProfilePlus += ",";
         fProfilePlus += fpId;
-        fProfile->setValue(fProfilePlus.c_str(), fProfilePlus.length() + 1);
+        *fProfile = fProfilePlus.c_str();
     }
     
     context.getOperationRegistry().registerOperation("CancelReservation", [&context] () {

--- a/src/ArduinoOcpp/Model/SmartCharging/SmartChargingService.cpp
+++ b/src/ArduinoOcpp/Model/SmartCharging/SmartChargingService.cpp
@@ -315,7 +315,7 @@ SmartChargingService::SmartChargingService(Context& context, std::shared_ptr<Fil
         if (!fProfilePlus.empty() && fProfilePlus.back() != ',')
             fProfilePlus += ",";
         fProfilePlus += fpId;
-        fProfile->setValue(fProfilePlus.c_str(), fProfilePlus.length() + 1);
+        *fProfile = fProfilePlus.c_str();
     }
 
     context.getOperationRegistry().registerOperation("ClearChargingProfile", [this] () {


### PR DESCRIPTION
This PR decouples the instantiation of Configuration objects from the storage format. It also allowed a little code clean up.

This addresses the integration of a custom key-value store instead of using the default implementation of ArduinoOcpp. The firmware can subclass `ConfigurationContainer` and load and store Configurations using the host system's key-value store. To facilitate this, the initialization of a Configuration takes a key and initial value now instead of a JSON object as used by the default key-value store.