### PR TITLE
Retry msg send only after WebSocket reconnect

### DIFF
--- a/src/ArduinoOcpp/Core/ConfigurationKeyValue.cpp
+++ b/src/ArduinoOcpp/Core/ConfigurationKeyValue.cpp
@@ -94,7 +94,7 @@ const T &Configuration<T>::operator=(const T & newVal) {
             const size_t VALUE_MAXSIZE = 50;
             char value_str [VALUE_MAXSIZE] = {'\0'};
             toCStringValue(value_str, VALUE_MAXSIZE, newVal);
-            AO_DBG_DEBUG("add config: key = %s, value = %s\n", getKey(), value_str);
+            AO_DBG_DEBUG("add config: key = %s, value = %s", getKey(), value_str);
         }
         if (initializedValue == true && value != newVal) {
             value_revision++;
@@ -224,7 +224,7 @@ const char *Configuration<const char *>::operator=(const char *new_value) {
     }
     
     if (!initializedValue) {
-        AO_DBG_DEBUG("add config: key = %s, value = %s\n", getKey(), value.c_str());
+        AO_DBG_DEBUG("add config: key = %s, value = %s", getKey(), value.c_str());
         (void)0;
     }
     initializedValue = true;

--- a/src/ArduinoOcpp/Core/Connection.cpp
+++ b/src/ArduinoOcpp/Core/Connection.cpp
@@ -47,7 +47,8 @@ bool WSClient::sendTXT(std::string &out) {
 
 void WSClient::setReceiveTXTcallback(ReceiveTXTcallback &callback) {
     auto& captureLastRecv = lastRecv;
-    wsock->onEvent([callback, &captureLastRecv](WStype_t type, uint8_t * payload, size_t length) {
+    auto& captureLastConnected = lastConnected;
+    wsock->onEvent([callback, &captureLastRecv, &captureLastConnected](WStype_t type, uint8_t * payload, size_t length) {
         switch (type) {
             case WStype_DISCONNECTED:
                 AO_DBG_INFO("Disconnected");
@@ -55,6 +56,7 @@ void WSClient::setReceiveTXTcallback(ReceiveTXTcallback &callback) {
             case WStype_CONNECTED:
                 AO_DBG_INFO("Connected to url: %s", payload);
                 captureLastRecv = ao_tick_ms();
+                captureLastConnected = ao_tick_ms();
                 break;
             case WStype_TEXT:
                 if (callback((const char *) payload, length)) { //forward message to RequestQueue
@@ -86,6 +88,10 @@ void WSClient::setReceiveTXTcallback(ReceiveTXTcallback &callback) {
 
 unsigned long WSClient::getLastRecv() {
     return lastRecv;
+}
+
+unsigned long WSClient::getLastConnected() {
+    return lastConnected;
 }
 
 #endif

--- a/src/ArduinoOcpp/Core/Connection.cpp
+++ b/src/ArduinoOcpp/Core/Connection.cpp
@@ -11,7 +11,7 @@ void LoopbackConnection::loop() { }
 
 bool LoopbackConnection::sendTXT(std::string &out) {
     if (!connected) {
-        return true;
+        return false;
     }
     if (receiveTXT) {
         lastRecv = ao_tick_ms();

--- a/src/ArduinoOcpp/Core/Connection.h
+++ b/src/ArduinoOcpp/Core/Connection.h
@@ -49,6 +49,11 @@ public:
      * Returns the timestamp of the last incoming message. Use ao_tick_ms() for creating the correct timestamp
      */
     virtual unsigned long getLastRecv() {return 0;}
+
+    /*
+     * Returns the timestamp of the last time a connection got successfully established. Use ao_tick_ms() for creating the correct timestamp
+     */
+    virtual unsigned long getLastConnected() {return 0;}
 };
 
 class LoopbackConnection : public Connection {
@@ -79,7 +84,7 @@ namespace EspWiFi {
 class WSClient : public Connection {
 private:
     WebSocketsClient *wsock;
-    unsigned long lastRecv = 0;
+    unsigned long lastRecv = 0, lastConnected = 0;
 public:
     WSClient(WebSocketsClient *wsock);
 
@@ -90,6 +95,8 @@ public:
     void setReceiveTXTcallback(ReceiveTXTcallback &receiveTXT);
 
     unsigned long getLastRecv() override; //get time of last successful receive in millis
+
+    unsigned long getLastConnected() override; //get last connection creation in millis
 };
 
 } //end namespace EspWiFi

--- a/src/ArduinoOcpp/Core/RequestQueue.cpp
+++ b/src/ArduinoOcpp/Core/RequestQueue.cpp
@@ -91,11 +91,11 @@ void RequestQueue::loop(Connection& ocppSock) {
         sendBackoffPeriod = 0;
     }
 
-    if (sockTrackLastRecv != ocppSock.getLastRecv()) {
+    if (sockTrackLastConnected != ocppSock.getLastConnected()) {
         //connection active (again) -> send immediately
         sendBackoffPeriod = std::min(sendBackoffPeriod, 1000UL);
     }
-    sockTrackLastRecv = ocppSock.getLastRecv();
+    sockTrackLastConnected = ocppSock.getLastConnected();
 
     if (ao_tick_ms() - sendBackoffTime < sendBackoffPeriod) {
         //still in backoff period

--- a/src/ArduinoOcpp/Core/RequestQueue.cpp
+++ b/src/ArduinoOcpp/Core/RequestQueue.cpp
@@ -117,12 +117,11 @@ void RequestQueue::loop(Connection& ocppSock) {
 
     if (success) {
         AO_DBG_TRAFFIC_OUT(out.c_str());
-    }
 
-    //update backoff time
-    sendBackoffTime = ao_tick_ms();
-    sendBackoffPeriod = std::min(sendBackoffPeriod + BACKOFF_PERIOD_INCREMENT, BACKOFF_PERIOD_MAX);
-    
+        //update backoff time
+        sendBackoffTime = ao_tick_ms();
+        sendBackoffPeriod = std::min(sendBackoffPeriod + BACKOFF_PERIOD_INCREMENT, BACKOFF_PERIOD_MAX);
+    }
 }
 
 void RequestQueue::sendRequest(std::unique_ptr<Request> op){

--- a/src/ArduinoOcpp/Core/RequestQueue.h
+++ b/src/ArduinoOcpp/Core/RequestQueue.h
@@ -32,8 +32,8 @@ private:
 
     unsigned long sendBackoffTime = 0;
     unsigned long sendBackoffPeriod = 0;
-    unsigned long sockTrackLastRecv = 0;
-    const unsigned long BACKOFF_PERIOD_MAX = 65536;
+    unsigned long sockTrackLastConnected = 0;
+    const unsigned long BACKOFF_PERIOD_MAX = 1048576;
     const unsigned long BACKOFF_PERIOD_INCREMENT = BACKOFF_PERIOD_MAX / 4;
 public:
     RequestQueue(OperationRegistry& operationRegistry, Model *baseModel, std::shared_ptr<FilesystemAdapter> filesystem = nullptr);


### PR DESCRIPTION
This PR changes the retry strategy of the Request queue. Instead of detecting offline periods and retrying after becoming online again, the new behavior only checks for WebSocket reconnects. The additional default backoff period of 15s has been extended to 4 minutes.

The previous strategy lead to a high number of duplicate messages with matching `messageId`s. The OCPP standard doesn't define how to handle multiple messages with the same ID and tests with different OCPP backends show that this behavior is problematic.

To support checking for reconnects, the `Connection` interface has a new function `ulong getLastConnected()` which returns the timestamp when the last underlying WebSocket connection was successfully established.